### PR TITLE
Change `dpkg -i` to use a wildcard for the version string.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone https://github.com/tpaskett/meshchat.git
 WORKDIR /root/meshchat
 
 RUN ./build
-RUN dpkg -i meshchat_1.0_all.deb
+RUN dpkg -i meshchat_*_all.deb
 
 EXPOSE 80
 


### PR DESCRIPTION
Fixes #1  by changing the `dpkg -i` command string to use a wildcard in place of the Meshchat version. So long as the overall format of the generated `.deb`'s name doesn't change, this works.